### PR TITLE
Suggestion: Provide environment YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,25 @@
 GeneExt takes as input scRNA-seq mapped reads and a gene annotation file (GTF or GFF, any version) and outputs an extended gene annotation file for improved scRNA-seq transcript quantification.
 
 # Installation  
+> **Note:** Users lacking a Conda installation are recommend to install [Miniforge](https://github.com/conda-forge/miniforge#miniforge).
 
-Tool dependencies can be installed with `conda` or `mamba`: 
+Tool dependencies can be installed with `conda` or `mamba`:
 
-```
+```bash
 # create environment
-conda create -n geneext
+conda env create -n geneext -f environment.yaml
+
+# activate environment
 conda activate geneext
-# install dependencies
-conda install -c bioconda -c conda-forge gffutils bedtools numpy macs2 samtools pysam rich pandas 
 ```
 
 # Test run
-Once dependencies are installed, try running `GeneExt` with sample data:  
-```
+Once dependencies are installed, try running `GeneExt` with sample data:
+
+```bash
 python geneext.py -g test_data/annotation.gtf -b test_data/alignments.bam -o result.gtf
 ```
+
 Please, first test whether the tool works properly on the test data! 
 
 For details on how to obtain alignment file, please refer to the [manual](Manual.md).   

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 GeneExt takes as input scRNA-seq mapped reads and a gene annotation file (GTF or GFF, any version) and outputs an extended gene annotation file for improved scRNA-seq transcript quantification.
 
 # Installation  
-> **Note:** Users lacking a Conda installation are recommend to install [Miniforge](https://github.com/conda-forge/miniforge#miniforge).
+> **Note:** Users lacking a Conda installation are recommended to install [Miniforge](https://github.com/conda-forge/miniforge#miniforge).
 
 Tool dependencies can be installed with `conda` or `mamba`:
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,14 @@
+name: geneext
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - bedtools
+  - gffutils
+  - macs2
+  - numpy
+  - pandas
+  - pysam
+  - rich
+  - samtools


### PR DESCRIPTION
This PR adds a YAML Conda environment definition and updates the README to use it. It also adds a recommendation for a Conda **base** installer that is suitable for bioinformatics users.

## Motivation
Providing a single definition of an environment in the form of YAML is less prone to mistakes by users. The YAML here improves on the current recommendation by 

- using the proper channel order (`conda-forge` must always precede `bioconda`)
- blocking user channels via a `nodefaults` instruction
- installing packages at creation time, rather than depending on activating

I suggest recommending for `Miniforge` **base** installer because it is minimal and prioritizes the `conda-forge` channel, which is consistent with Bioconda.